### PR TITLE
feat: recursively extract files from nested parameters

### DIFF
--- a/src/Methods/BaseMethodGroup.php
+++ b/src/Methods/BaseMethodGroup.php
@@ -57,18 +57,29 @@ abstract class BaseMethodGroup
     /**
      * 提取文件参数
      */
-    protected function extractFiles(array $parameters): array
+    protected function extractFiles(array &$parameters): array
     {
         $files = [];
-
-        foreach ($parameters as $key => $value) {
-            if (is_string($value) && $this->isFilePath($value)) {
-                $files[$key] = $value;
-                unset($parameters[$key]);
-            }
-        }
+        $this->walkFiles($parameters, $files);
 
         return $files;
+    }
+
+    /**
+     * 递归遍历参数并提取文件
+     */
+    private function walkFiles(array &$parameters, array &$files, string $prefix = ''): void
+    {
+        foreach ($parameters as $key => &$value) {
+            $currentKey = $prefix === '' ? (string) $key : $prefix . '_' . $key;
+
+            if (is_array($value)) {
+                $this->walkFiles($value, $files, $currentKey);
+            } elseif ((is_string($value) || is_resource($value)) && $this->isFilePath((string) $value)) {
+                $files[$currentKey] = $value;
+                $value = "attach://{$currentKey}";
+            }
+        }
     }
 
     /**

--- a/src/Methods/MessageMethods.php
+++ b/src/Methods/MessageMethods.php
@@ -88,13 +88,14 @@ class MessageMethods extends BaseMethodGroup
         $this->validateChatId($chatId);
         $this->validateMessageId($messageId);
 
-        $parameters = $this->prepareParameters(array_merge([
+        $parameters = array_merge([
             'chat_id' => $chatId,
             'message_id' => $messageId,
             'media' => $media,
-        ], $options));
+        ], $options);
 
         $files = $this->extractFiles($parameters);
+        $parameters = $this->prepareParameters($parameters);
         
         if (!empty($files)) {
             $response = $this->upload('editMessageMedia', $parameters, $files);
@@ -308,12 +309,13 @@ class MessageMethods extends BaseMethodGroup
     ): Message {
         $this->validateChatId($chatId);
 
-        $parameters = $this->prepareParameters(array_merge([
+        $parameters = array_merge([
             'chat_id' => $chatId,
             'photo' => $photo,
-        ], $options));
+        ], $options);
 
-        $files = $this->extractFiles(['photo' => $photo]);
+        $files = $this->extractFiles($parameters);
+        $parameters = $this->prepareParameters($parameters);
         
         if (!empty($files)) {
             $response = $this->upload('sendPhoto', $parameters, $files);
@@ -334,12 +336,13 @@ class MessageMethods extends BaseMethodGroup
     ): Message {
         $this->validateChatId($chatId);
 
-        $parameters = $this->prepareParameters(array_merge([
+        $parameters = array_merge([
             'chat_id' => $chatId,
             'audio' => $audio,
-        ], $options));
+        ], $options);
 
-        $files = $this->extractFiles(['audio' => $audio]);
+        $files = $this->extractFiles($parameters);
+        $parameters = $this->prepareParameters($parameters);
         
         if (!empty($files)) {
             $response = $this->upload('sendAudio', $parameters, $files);
@@ -360,12 +363,13 @@ class MessageMethods extends BaseMethodGroup
     ): Message {
         $this->validateChatId($chatId);
 
-        $parameters = $this->prepareParameters(array_merge([
+        $parameters = array_merge([
             'chat_id' => $chatId,
             'document' => $document,
-        ], $options));
+        ], $options);
 
-        $files = $this->extractFiles(['document' => $document]);
+        $files = $this->extractFiles($parameters);
+        $parameters = $this->prepareParameters($parameters);
         
         if (!empty($files)) {
             $response = $this->upload('sendDocument', $parameters, $files);
@@ -386,12 +390,13 @@ class MessageMethods extends BaseMethodGroup
     ): Message {
         $this->validateChatId($chatId);
 
-        $parameters = $this->prepareParameters(array_merge([
+        $parameters = array_merge([
             'chat_id' => $chatId,
             'video' => $video,
-        ], $options));
+        ], $options);
 
-        $files = $this->extractFiles(['video' => $video]);
+        $files = $this->extractFiles($parameters);
+        $parameters = $this->prepareParameters($parameters);
         
         if (!empty($files)) {
             $response = $this->upload('sendVideo', $parameters, $files);
@@ -412,12 +417,13 @@ class MessageMethods extends BaseMethodGroup
     ): Message {
         $this->validateChatId($chatId);
 
-        $parameters = $this->prepareParameters(array_merge([
+        $parameters = array_merge([
             'chat_id' => $chatId,
             'animation' => $animation,
-        ], $options));
+        ], $options);
 
-        $files = $this->extractFiles(['animation' => $animation]);
+        $files = $this->extractFiles($parameters);
+        $parameters = $this->prepareParameters($parameters);
         
         if (!empty($files)) {
             $response = $this->upload('sendAnimation', $parameters, $files);
@@ -438,12 +444,13 @@ class MessageMethods extends BaseMethodGroup
     ): Message {
         $this->validateChatId($chatId);
 
-        $parameters = $this->prepareParameters(array_merge([
+        $parameters = array_merge([
             'chat_id' => $chatId,
             'voice' => $voice,
-        ], $options));
+        ], $options);
 
-        $files = $this->extractFiles(['voice' => $voice]);
+        $files = $this->extractFiles($parameters);
+        $parameters = $this->prepareParameters($parameters);
         
         if (!empty($files)) {
             $response = $this->upload('sendVoice', $parameters, $files);
@@ -464,12 +471,13 @@ class MessageMethods extends BaseMethodGroup
     ): Message {
         $this->validateChatId($chatId);
 
-        $parameters = $this->prepareParameters(array_merge([
+        $parameters = array_merge([
             'chat_id' => $chatId,
             'video_note' => $videoNote,
-        ], $options));
+        ], $options);
 
-        $files = $this->extractFiles(['video_note' => $videoNote]);
+        $files = $this->extractFiles($parameters);
+        $parameters = $this->prepareParameters($parameters);
         
         if (!empty($files)) {
             $response = $this->upload('sendVideoNote', $parameters, $files);
@@ -498,23 +506,13 @@ class MessageMethods extends BaseMethodGroup
             throw new \InvalidArgumentException('Media array cannot contain more than 10 items');
         }
 
-        $parameters = $this->prepareParameters(array_merge([
+        $parameters = array_merge([
             'chat_id' => $chatId,
             'media' => $media,
-        ], $options));
+        ], $options);
 
-        // 检查是否有文件需要上传
-        $files = [];
-        foreach ($media as $index => $mediaItem) {
-            if (isset($mediaItem['media']) && $this->isFilePath($mediaItem['media'])) {
-                $fileKey = "media_{$index}";
-                $files[$fileKey] = $mediaItem['media'];
-                $media[$index]['media'] = "attach://{$fileKey}";
-            }
-        }
-
-        // 重新设置媒体参数
-        $parameters['media'] = json_encode($media);
+        $files = $this->extractFiles($parameters);
+        $parameters = $this->prepareParameters($parameters);
 
         if (!empty($files)) {
             $response = $this->upload('sendMediaGroup', $parameters, $files);

--- a/tests/Unit/ExtractFilesTest.php
+++ b/tests/Unit/ExtractFilesTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use XBot\Telegram\Contracts\HttpClientInterface;
+use XBot\Telegram\Methods\BaseMethodGroup;
+use XBot\Telegram\Models\Response\TelegramResponse;
+
+class DummyHttpClient implements HttpClientInterface
+{
+    public function get(string $method, array $parameters = []): TelegramResponse
+    {
+        return new TelegramResponse(['ok' => true, 'result' => null]);
+    }
+
+    public function post(string $method, array $parameters = []): TelegramResponse
+    {
+        return new TelegramResponse(['ok' => true, 'result' => null]);
+    }
+
+    public function upload(string $method, array $parameters = [], array $files = []): TelegramResponse
+    {
+        return new TelegramResponse(['ok' => true, 'result' => null]);
+    }
+
+    public function getToken(): string
+    {
+        return '';
+    }
+
+    public function getBaseUrl(): string
+    {
+        return '';
+    }
+
+    public function getConfig(): array
+    {
+        return [];
+    }
+
+    public function setTimeout(int $timeout): static
+    {
+        return $this;
+    }
+
+    public function setRetryAttempts(int $attempts): static
+    {
+        return $this;
+    }
+
+    public function setRetryDelay(int $delay): static
+    {
+        return $this;
+    }
+
+    public function getLastResponse(): ?TelegramResponse
+    {
+        return null;
+    }
+
+    public function getLastError(): ?\Throwable
+    {
+        return null;
+    }
+}
+
+class TestMethodGroup extends BaseMethodGroup
+{
+    public function extract(array &$parameters): array
+    {
+        return $this->extractFiles($parameters);
+    }
+}
+
+it('extracts top-level files', function () {
+    $temp = tempnam(sys_get_temp_dir(), 'tg');
+    file_put_contents($temp, 'a');
+
+    $group = new TestMethodGroup(new DummyHttpClient(), 'bot');
+
+    $params = ['photo' => $temp, 'chat_id' => 1];
+    $files = $group->extract($params);
+
+    expect($files)->toHaveKey('photo', $temp);
+    expect($params['photo'])->toBe('attach://photo');
+});
+
+it('extracts nested media files', function () {
+    $temp = tempnam(sys_get_temp_dir(), 'tg');
+    file_put_contents($temp, 'a');
+
+    $group = new TestMethodGroup(new DummyHttpClient(), 'bot');
+
+    $params = ['media' => [['type' => 'photo', 'media' => $temp]]];
+    $files = $group->extract($params);
+
+    expect($files)->toHaveKey('media_0_media', $temp);
+    expect($params['media'][0]['media'])->toBe('attach://media_0_media');
+});


### PR DESCRIPTION
## Summary
- handle nested file paths by recursively walking parameter arrays
- ensure upload methods remove local paths and use attach placeholders
- add unit tests for flat and nested file extraction

## Testing
- `vendor/bin/pest tests/Unit/ExtractFilesTest.php`
- `vendor/bin/pest`
- `vendor/bin/phpstan analyse src tests`

------
https://chatgpt.com/codex/tasks/task_e_68b0b6470c548330a0b4d0ac72c10fe4