### PR TITLE
fix: guard BotManager memory usage estimation

### DIFF
--- a/src/BotManager.php
+++ b/src/BotManager.php
@@ -435,11 +435,18 @@ class BotManager implements BotManagerInterface
     protected function getObjectMemoryUsage(object $obj): int
     {
         $startMemory = memory_get_usage();
-        $tmp         = unserialize(serialize($obj));
-        $endMemory   = memory_get_usage();
-        unset($tmp);
 
-        return $endMemory - $startMemory;
+        try {
+            $tmp       = unserialize(serialize($obj));
+            $endMemory = memory_get_usage();
+            unset($tmp);
+
+            return max(0, $endMemory - $startMemory);
+        } catch (\Throwable $e) {
+            error_log('Failed to serialize object for memory usage: ' . $e->getMessage());
+
+            return max(0, memory_get_usage() - $startMemory);
+        }
     }
 
     /**

--- a/tests/Unit/BotManagerMemoryUsageTest.php
+++ b/tests/Unit/BotManagerMemoryUsageTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use XBot\Telegram\BotManager;
+
+class BotManagerMemoryUsageStub extends BotManager
+{
+    public function getUsage(object $obj): int
+    {
+        return $this->getObjectMemoryUsage($obj);
+    }
+}
+
+it('handles objects with resources and closures when estimating memory', function () {
+    $config = [
+        'default' => 'test',
+        'bots'    => [
+            'test' => [
+                'token'    => '1234567890:AA',
+                'base_url' => 'https://api.telegram.org/bot',
+                'timeout'  => 30,
+            ],
+        ],
+    ];
+
+    $manager = new BotManagerMemoryUsageStub($config);
+
+    $resource = fopen('php://temp', 'r');
+    $object   = new class($resource) {
+        public $handle;
+        public $closure;
+
+        public function __construct($handle)
+        {
+            $this->handle  = $handle;
+            $this->closure = fn () => null;
+        }
+    };
+
+    $result = $manager->getUsage($object);
+
+    expect($result)->toBeInt()->toBeGreaterThanOrEqual(0);
+    fclose($resource);
+});


### PR DESCRIPTION
## Summary
- handle serialization failures when estimating object memory use
- add test covering resources and closures

## Testing
- `vendor/bin/pest tests/Unit/BotManagerMemoryUsageTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68b0b6489d588330ba301f3c3b51340b