### PR TITLE
feat: make token validation configurable

### DIFF
--- a/config/telegram.php
+++ b/config/telegram.php
@@ -90,6 +90,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Bot Token Validation
+    |--------------------------------------------------------------------------
+    |
+    | 控制 Bot Token 的严格校验。可通过 pattern 覆盖默认正则，或设置 enabled
+    | 为 false 关闭验证。
+    |
+    */
+    'token_validation' => [
+        'enabled' => env('TELEGRAM_VALIDATE_TOKEN', true),
+        'pattern' => env('TELEGRAM_TOKEN_PATTERN', '^\d+:[A-Za-z0-9_-]{32,}$'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Bot Instances Configuration
     |--------------------------------------------------------------------------
     |
@@ -104,6 +118,10 @@ return [
     'bots' => [
         'main' => [
             'token' => env('TELEGRAM_MAIN_BOT_TOKEN'),
+            // 'token_validation' => [ // 可覆盖或关闭严格校验
+            //     'enabled' => env('TELEGRAM_MAIN_VALIDATE_TOKEN', true),
+            //     'pattern' => env('TELEGRAM_MAIN_TOKEN_PATTERN', null),
+            // ],
             'http_template' => env('TELEGRAM_MAIN_HTTP_TEMPLATE', 'standard'),
             'http_overrides' => [
                 'timeout' => (int) env('TELEGRAM_TIMEOUT', null), // 覆盖模板配置

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -32,6 +32,10 @@ Bot::init([
 ]);
 ```
 
+> 默认会使用 `^\d+:[A-Za-z0-9_-]{32,}$` 正则严格校验 Bot Token。
+> 可通过 `token_validation.pattern` 覆盖此规则，或设置
+> `token_validation.enabled` 为 `false` 关闭校验。
+
 ## 🏗️ 基础配置
 
 ### 1. HTTP 客户端配置
@@ -547,7 +551,7 @@ function validateConfig(array $config): array
         $errors[] = 'Bot token 不能为空';
     }
     
-    if (!preg_match('/^\d+:[A-Za-z0-9_-]+$/', $config['token'] ?? '')) {
+    if (!preg_match('/^\d+:[A-Za-z0-9_-]{32,}$/', $config['token'] ?? '')) {
         $errors[] = 'Bot token 格式无效';
     }
     

--- a/src/TelegramBot.php
+++ b/src/TelegramBot.php
@@ -83,7 +83,12 @@ class TelegramBot implements TelegramBotInterface
             throw ConfigurationException::missingBotToken($this->name);
         }
 
-        if (!preg_match('/^\d{8,10}:[a-zA-Z0-9_-]{35}$/', $token)) {
+        $tokenValidation = $this->config['token_validation'] ?? [
+            'enabled' => true,
+            'pattern' => '/^\d+:[a-zA-Z0-9_-]{32,}$/',
+        ];
+
+        if (! empty($tokenValidation['enabled']) && ! preg_match($tokenValidation['pattern'], $token)) {
             throw ConfigurationException::invalidBotToken($token, $this->name);
         }
     }

--- a/tests/Unit/TokenValidationTest.php
+++ b/tests/Unit/TokenValidationTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use XBot\Telegram\BotManager;
+use XBot\Telegram\TelegramBot;
+use XBot\Telegram\Exceptions\InstanceException;
+
+it('accepts valid token with default validation', function () {
+    $config = [
+        'default' => 'main',
+        'bots' => [
+            'main' => [
+                'token' => '123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi',
+            ],
+        ],
+    ];
+
+    $manager = new BotManager($config);
+    $bot = $manager->bot();
+
+    expect($bot)->toBeInstanceOf(TelegramBot::class);
+});
+
+it('throws exception for invalid token format by default', function () {
+    $config = [
+        'default' => 'main',
+        'bots' => [
+            'main' => [
+                'token' => 'invalid-token',
+            ],
+        ],
+    ];
+
+    $manager = new BotManager($config);
+
+    expect(fn() => $manager->bot())->toThrow(InstanceException::class);
+});
+
+it('allows overriding token pattern', function () {
+    $config = [
+        'default' => 'main',
+        'token_validation' => [
+            'pattern' => '/^test_token$/',
+        ],
+        'bots' => [
+            'main' => [
+                'token' => 'test_token',
+            ],
+        ],
+    ];
+
+    $manager = new BotManager($config);
+    $bot = $manager->bot();
+
+    expect($bot->getToken())->toBe('test_token');
+});
+
+it('can disable token validation', function () {
+    $config = [
+        'default' => 'main',
+        'token_validation' => [
+            'enabled' => false,
+        ],
+        'bots' => [
+            'main' => [
+                'token' => 'invalid token',
+            ],
+        ],
+    ];
+
+    $manager = new BotManager($config);
+    $bot = $manager->bot();
+
+    expect($bot->getToken())->toBe('invalid token');
+});


### PR DESCRIPTION
## Summary
- allow overriding or disabling bot token validation
- document token validation options and examples
- cover token validation with dedicated tests

## Testing
- `vendor/bin/pest tests/Unit/TokenValidationTest.php`
- `vendor/bin/pest`
- `vendor/bin/phpstan analyse src tests`

------
https://chatgpt.com/codex/tasks/task_e_68b0b64a1c008330b59fec4f8bee0354