### PR TITLE
feat(bot): add token entrypoint

### DIFF
--- a/docs/examples/basic-usage.md
+++ b/docs/examples/basic-usage.md
@@ -13,19 +13,13 @@ require_once 'vendor/autoload.php';
 
 use XBot\\Telegram\\Bot;
 
-Bot::init([
-    'default' => 'main',
-    'bots' => [
-        'main' => ['token' => 'YOUR_BOT_TOKEN'],
-    ],
-]);
-
 // 一行发送
-Bot::to(123456789)->message('Hello, World!');
+Bot::token('YOUR_BOT_TOKEN')
+    ->message->sendMessage(123456789, 'Hello, World!');
 
 // 或获取实例执行更多操作
-$bot = Bot::bot();
-$bot->sendMessage(123456789, 'Hello again!');
+$bot = Bot::token('YOUR_BOT_TOKEN');
+$bot->message->sendMessage(123456789, 'Hello again!');
 ```
 
 ### 1. 创建第一个 Bot
@@ -35,20 +29,13 @@ $bot->sendMessage(123456789, 'Hello again!');
 
 require_once 'vendor/autoload.php';
 
-use XBot\Telegram\BotManager;
-use XBot\Telegram\Http\GuzzleHttpClient;
-
-// 创建 HTTP 客户端
-$httpClient = new GuzzleHttpClient('YOUR_BOT_TOKEN');
-
-// 创建 Bot 管理器
-$manager = new BotManager();
+use XBot\\Telegram\\Bot;
 
 // 创建 Bot 实例
-$bot = $manager->createBot('my-bot', $httpClient);
+$bot = Bot::token('YOUR_BOT_TOKEN');
 
 // 发送第一条消息
-$message = $bot->sendMessage(123456789, 'Hello, World!');
+$message = $bot->message->sendMessage(123456789, 'Hello, World!');
 echo "消息已发送，ID: " . $message->messageId;
 ```
 

--- a/tests/Unit/BotTokenTest.php
+++ b/tests/Unit/BotTokenTest.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use XBot\Telegram\Bot;
+use XBot\Telegram\TelegramBot;
+
+it('creates telegram bot from token', function () {
+    $bot = Bot::token('123:ABC');
+
+    expect($bot)->toBeInstanceOf(TelegramBot::class);
+    expect($bot->getToken())->toBe('123:ABC');
+});
+

--- a/tests/Unit/KeyboardAndCommandsTest.php
+++ b/tests/Unit/KeyboardAndCommandsTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use XBot\Telegram\TelegramBot;
 use XBot\Telegram\Tests\Support\FakeHttpClient;
-use XBot\Telegram\Bot;
 
 it('BotMessage builds inline and reply keyboards and removal/forceReply', function () {
     $sent = [];
@@ -13,8 +12,7 @@ it('BotMessage builds inline and reply keyboards and removal/forceReply', functi
         return ['ok' => true, 'result' => ['message_id' => rand(1, 1000), 'date' => time(), 'chat' => ['id' => 1, 'type' => 'private']]];
     });
 
-    Bot::useManager(new \XBot\Telegram\BotManager(['default' => 'd', 'bots' => ['d' => ['token' => 'T']]]));
-    // Inject bot into Bot facade-like entry by replacing via quick call
+    // Inject bot into BotMessage helper using a fake client
     $bot = new TelegramBot('d', $client);
 
     // Inline keyboard


### PR DESCRIPTION
## Summary
- simplify Bot facade with `token()` to create a `TelegramBot`
- update basic usage docs to use `Bot::token('TOKEN')`
- cover new entrypoint with tests

## Testing
- `vendor/bin/pest` *(fails: Tests: 2 deprecated, 124 failed, 107 passed (452 assertions))*
- `vendor/bin/phpstan analyse src tests` *(configuration warning)*

------
https://chatgpt.com/codex/tasks/task_e_68b0fcfa29d0833096ab85013033415a