### PR TITLE
feat(update): add logOut and close methods

### DIFF
--- a/docs/api/methods/update.md
+++ b/docs/api/methods/update.md
@@ -1,5 +1,23 @@
 # update
 
-📝 此文档正在编写中，敬请期待！
+更新方法用于管理 Bot 与 Telegram 服务器之间的连接。
 
-> 💡 如果您需要此内容，请在 [GitHub Issues](https://github.com/xbot-my/telegram-sdk/issues) 中反馈。
+## logOut
+
+注销当前 Bot 会话，通常用于从 Webhook 切换到长轮询等场景。
+
+```php
+$bot->logOut();
+```
+
+返回 `true` 表示注销成功。
+
+## close
+
+关闭与 Telegram 的连接并释放资源。
+
+```php
+$bot->close();
+```
+
+返回 `true` 表示关闭成功。

--- a/docs/examples/basic-usage.md
+++ b/docs/examples/basic-usage.md
@@ -204,6 +204,16 @@ $bot->editMessageReplyMarkup($chatId, $messageId, [
 $bot->deleteMessage($chatId, $messageId);
 ```
 
+### 注销和关闭 Bot
+
+```php
+// 注销当前 Bot 会话
+$bot->logOut();
+
+// 关闭连接并释放资源
+$bot->close();
+```
+
 ## 🛠️ 错误处理
 
 ```php

--- a/src/Contracts/TelegramBotInterface.php
+++ b/src/Contracts/TelegramBotInterface.php
@@ -32,6 +32,16 @@ interface TelegramBotInterface
     public function getMe(): User;
 
     /**
+     * 注销 Bot
+     */
+    public function logOut(): bool;
+
+    /**
+     * 关闭 Bot
+     */
+    public function close(): bool;
+
+    /**
      * 发送消息
      */
     public function sendMessage(

--- a/src/TelegramBot.php
+++ b/src/TelegramBot.php
@@ -90,6 +90,16 @@ class TelegramBot
         return $this->botInfo;
     }
 
+    public function logOut(): bool
+    {
+        return $this->methods('update')->logOut();
+    }
+
+    public function close(): bool
+    {
+        return $this->methods('update')->close();
+    }
+
     public function methods(string $group): BaseMethodGroup
     {
         $group = strtolower($group);

--- a/tests/Unit/UpdateTest.php
+++ b/tests/Unit/UpdateTest.php
@@ -12,6 +12,11 @@ use XBot\Telegram\Models\DTO\ChosenInlineResult;
 use XBot\Telegram\Models\DTO\Poll;
 use XBot\Telegram\Models\DTO\PollAnswer;
 use XBot\Telegram\Exceptions\ValidationException;
+use XBot\Telegram\TelegramBot;
+use XBot\Telegram\Contracts\TelegramBotInterface;
+use XBot\Telegram\Tests\Support\FakeHttpClient;
+
+uses(XBot\Telegram\Tests\TestCase::class);
 
 beforeEach(function () {
     $this->baseUpdateId = 12345;
@@ -22,6 +27,33 @@ beforeEach(function () {
     $this->userData = $this->createMockUser($this->baseUserId, 'TestUser', false);
     $this->chatData = $this->createMockChat($this->baseChatId, 'private');
     $this->messageData = $this->createMockMessage(1, $this->baseChatId, 'Hello World', $this->baseUserId);
+});
+
+
+describe('logOut 和 close 方法', function () {
+    it('通过接口调用 logOut', function () {
+        $client = new FakeHttpClient(handler: function ($method, $params) {
+            expect($method)->toBe('logOut');
+            expect($params)->toBe([]);
+            return ['ok' => true, 'result' => true];
+        });
+
+        /** @var TelegramBotInterface $bot */
+        $bot = new TelegramBot('test', $client);
+        expect($bot->logOut())->toBeTrue();
+    });
+
+    it('通过接口调用 close', function () {
+        $client = new FakeHttpClient(handler: function ($method, $params) {
+            expect($method)->toBe('close');
+            expect($params)->toBe([]);
+            return ['ok' => true, 'result' => true];
+        });
+
+        /** @var TelegramBotInterface $bot */
+        $bot = new TelegramBot('test', $client);
+        expect($bot->close())->toBeTrue();
+    });
 });
 
 describe('Update DTO 测试', function () {


### PR DESCRIPTION
## Summary
- add `logOut` and `close` to bot contract and implementation
- document new update methods and examples
- cover bot logout and close behaviors with unit tests

## Testing
- `vendor/bin/phpstan analyse src tests --no-progress`
- `vendor/bin/pest tests/Unit/UpdateTest.php --filter='logOut' --no-progress`


------
https://chatgpt.com/codex/tasks/task_e_68b0fd05a24883308e4aca12388fd403